### PR TITLE
use zoom parameter if passed

### DIFF
--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -164,7 +164,7 @@ export var TileLayer = GridLayer.extend({
 			s: this._getSubdomain(coords),
 			x: coords.x,
 			y: coords.y,
-			z: this._getZoomForUrl()
+			z: coords.z ? coords.z : this._getZoomForUrl()
 		};
 		if (this._map && !this._map.options.crs.infinite) {
 			var invertedY = this._globalTileRange.max.y - coords.y;


### PR DESCRIPTION
We have an offline layer, which caches the tiles and we need to generate URL for various zoom level (https://github.com/mWater/offline-leaflet-map). We did override this method there but I think this should also be supported in leaflet itself!

It only supplies the z parameter from the current zoom level of the map right now